### PR TITLE
feat(posts-model): add posts data model and documentation

### DIFF
--- a/.appwrite/appwrite.json
+++ b/.appwrite/appwrite.json
@@ -10,11 +10,7 @@
     "collections": [
         {
             "$id": "profiles",
-            "$permissions": [
-                "create(\"users\")",
-                "read(\"users\")",
-                "update(\"users\")"
-            ],
+            "$permissions": ["create(\"users\")", "read(\"users\")", "update(\"users\")"],
             "databaseId": "main",
             "name": "profiles",
             "enabled": true,
@@ -49,9 +45,7 @@
                     "type": "string",
                     "required": false,
                     "array": true,
-                    "elements": [
-                        "private"
-                    ],
+                    "elements": ["private"],
                     "format": "enum",
                     "default": null
                 }
@@ -61,12 +55,115 @@
                     "key": "username_index",
                     "type": "unique",
                     "status": "available",
-                    "attributes": [
-                        "username"
-                    ],
-                    "orders": [
-                        "ASC"
-                    ]
+                    "attributes": ["username"],
+                    "orders": ["ASC"]
+                }
+            ]
+        },
+        {
+            "$id": "posts",
+            "$permissions": [
+                "create(\"users\")",
+                "read(\"any\")",
+                "update(\"users\")",
+                "delete(\"users\")"
+            ],
+            "databaseId": "main",
+            "name": "posts",
+            "enabled": true,
+            "documentSecurity": true,
+            "attributes": [
+                {
+                    "key": "userId",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 255
+                },
+                {
+                    "key": "createdAt",
+                    "type": "datetime",
+                    "required": true,
+                    "array": false
+                },
+                {
+                    "key": "updatedAt",
+                    "type": "datetime",
+                    "required": true,
+                    "array": false
+                },
+                {
+                    "key": "type",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 50,
+                    "elements": ["image", "text", "blog", "video", "imessage"],
+                    "format": "enum"
+                },
+                {
+                    "key": "tags",
+                    "type": "string",
+                    "required": false,
+                    "array": true,
+                    "size": 50
+                },
+                {
+                    "key": "likesCount",
+                    "type": "integer",
+                    "required": true,
+                    "array": false
+                },
+                {
+                    "key": "commentsCount",
+                    "type": "integer",
+                    "required": true,
+                    "array": false
+                },
+                {
+                    "key": "status",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 20,
+                    "elements": ["published", "draft", "archived"],
+                    "format": "enum"
+                },
+                {
+                    "key": "accessLevel",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 20,
+                    "elements": ["public", "private", "followers", "mutuals", "unlisted", "team"],
+                    "format": "enum"
+                },
+                {
+                    "key": "contentRefId",
+                    "type": "string",
+                    "required": false,
+                    "array": false,
+                    "size": 255
+                }
+            ],
+            "indexes": [
+                {
+                    "key": "user_created_index",
+                    "type": "key",
+                    "attributes": ["userId", "createdAt"],
+                    "orders": ["DESC", "DESC"]
+                },
+                {
+                    "key": "type_index",
+                    "type": "key",
+                    "attributes": ["type"],
+                    "orders": ["ASC"]
+                },
+                {
+                    "key": "access_level_index",
+                    "type": "key",
+                    "attributes": ["accessLevel"],
+                    "orders": ["ASC"]
                 }
             ]
         }

--- a/docs/database/posts-model.md
+++ b/docs/database/posts-model.md
@@ -1,0 +1,40 @@
+# Posts Data Model
+
+This document describes the data model for the `posts` collection in the Appwrite database, which serves as the central entry point for all types of user-generated content.
+
+## Collection: `posts`
+
+**Purpose:** To store fundamental information and metadata common to all post types, such as author, timestamps, type, and access control, while linking to the specific content stored in separate collections.
+
+**Appwrite Database:** `main`
+
+**Key Attributes:**
+
+- **`userId`**: Identifies the user who created the post.
+- **`createdAt`**: The date and time the post was initially created.
+- **`updatedAt`**: The date and time the post was last modified.
+- **`type`**: Specifies the nature of the post content (e.g., image, text, blog, video, imessage). Used to determine which content-specific collection to reference.
+- **`tags`**: An optional list of keywords or topics associated with the post.
+- **`likesCount`**: A counter for the number of likes or reactions.
+- **`commentsCount`**: A counter for the number of comments.
+- **`status`**: Indicates the current state of the post (e.g., published, draft, archived).
+- **`accessLevel`**: Controls the visibility and privacy of the post (e.g., public, private, followers, mutuals, unlisted, team).
+- **`contentRefId`**: The ID of the document in the relevant content-specific collection that holds the detailed post content.
+
+**Permissions:**
+
+Access permissions are configured in `appwrite.json` to allow users to create, read, update, and delete posts. Note that while `read("any")` is set on the collection for broad access, the `accessLevel` attribute and application-level logic are used to enforce finer-grained visibility rules for individual posts.
+
+**Indexing:**
+
+Indexes are defined in `appwrite.json` to optimize common queries:
+
+- An index on `userId` and `createdAt` to efficiently fetch a user's posts ordered by time.
+- An index on `type` for filtering posts by their content category.
+- An index on `accessLevel` for filtering posts based on their visibility settings.
+
+**Relationship to Content:**
+
+Instead of embedding all content directly, the `posts` collection links to separate collections (e.g., `imessageConversations`, `blogPosts`) using the `contentRefId`. This modular approach keeps the main `posts` collection streamlined and allows for varied and complex structures for different post types. When viewing a post, the application fetches the post document from the `posts` collection and then uses `contentRefId` and `type` to retrieve the corresponding detailed content from the appropriate linked collection.
+
+This structure balances the need for a unified view of all posts with the flexibility required to handle diverse content types and their specific data needs.

--- a/features/posts-model-ai-context.md
+++ b/features/posts-model-ai-context.md
@@ -1,0 +1,58 @@
+# Posts Model AI Context
+
+This document provides context and details about the `posts` collection in Appwrite, designed to store general information about various types of user posts.
+
+## Collection: `posts`
+
+**Purpose:** To serve as a central collection for all post types, storing common attributes and linking to type-specific content.
+
+**Appwrite Database:** `main`
+
+**Attributes:**
+
+- `userId` (String): Creator of the post. Required. Indexed for querying user's posts.
+- `createdAt` (Datetime): Post creation timestamp. Required. Indexed for ordering by recency.
+- `updatedAt` (Datetime): Last update timestamp. Required.
+- `type` (String Enum: 'image', 'text', 'blog', 'video', 'imessage'): Defines the type of content. Required. Indexed for filtering by type.
+- `tags` (Array of Strings): Tags associated with the post. Optional.
+- `likesCount` (Integer): Number of likes. Required, defaults to 0 handled by application logic on creation.
+- `commentsCount` (Integer): Number of comments. Required, defaults to 0 handled by application logic on creation.
+- `status` (String Enum: 'published', 'draft', 'archived'): Post status. Required, defaults to 'draft' handled by application logic on creation.
+- `accessLevel` (String Enum: 'public', 'private', 'followers', 'mutuals', 'unlisted', 'team'): Visibility setting. Required, defaults to 'public' handled by application logic on creation.
+- `contentRefId` (String): Reference to the document in the type-specific content collection (e.g., `imessageConversations`, `blogPosts`). Optional (initially might not have content until published/saved).
+
+**Permissions:**
+
+- `create("users")`: Any logged-in user can create a post.
+- `read("any")`: Anyone (logged-in or not) can read posts. _Note: Granular access control is handled by the `accessLevel` attribute and application logic when querying._
+- `update("users")`: Any logged-in user can update a post. _Note: Application logic should enforce that only the post owner or authorized users can update._
+- `delete("users")`: Any logged-in user can delete a post. _Note: Application logic should enforce that only the post owner or authorized users can delete._
+
+**Indexing:**
+
+- `user_created_index` (Key Index): On `userId` (DESC) and `createdAt` (DESC). Optimized for fetching a user's most recent posts.
+- `type_index` (Key Index): On `type` (ASC). Optimized for filtering posts by type.
+- `access_level_index` (Key Index): On `accessLevel` (ASC). Optimized for filtering posts by visibility.
+
+## Relationship to Content Collections
+
+The `posts` collection uses the `contentRefId` attribute to link to separate collections for detailed content based on the `type`:
+
+- `image` posts: Will link to an `imagePosts` collection.
+- `text` posts: Will link to a `textPosts` collection.
+- `blog` posts: Will link to a `blogPosts` collection.
+- `video` posts: Will link to a `videoPosts` collection.
+- `imessage` posts: Will link to an `imessageConversations` collection.
+
+This separation keeps the `posts` collection lean and allows for flexible, complex schemas in content-specific collections.
+
+## Querying Considerations
+
+When displaying lists of posts (e.g., in a feed), typically query the `posts` collection first, filtering by `accessLevel`, `type`, `userId`, and sorting by `createdAt`. Full content is fetched from the linked collection via `contentRefId` only when viewing a single post.
+
+## Potential Future Enhancements/Considerations
+
+- Implementing reporting or moderation flags.
+- Adding a `parentPostId` for replies or threads.
+- More advanced indexing for complex query patterns.
+- Using Appwrite Functions for triggers on post creation/update (e.g., updating denormalized counts).


### PR DESCRIPTION
Introduces the core 'posts' collection in Appwrite to centralize post metadata.
Includes attributes for userId, type, timestamps, tags, engagement counts, status, access level, and a reference to type-specific content collections.

Also adds:
- .appwrite/appwrite.json updates with the new collection and its attributes/indexes.
- features/posts-model-ai-context.md for AI reference.
- docs/database/posts-model.md for human documentation.