### PR TITLE
feat(imessage-model): add imessage data models and documentation

### DIFF
--- a/.appwrite/appwrite.json
+++ b/.appwrite/appwrite.json
@@ -166,6 +166,204 @@
                     "orders": ["ASC"]
                 }
             ]
+        },
+        {
+            "$id": "imessageParticipants",
+            "$permissions": [
+                "create(\"users\")",
+                "read(\"users\")",
+                "update(\"users\")",
+                "delete(\"users\")"
+            ],
+            "databaseId": "main",
+            "name": "imessageParticipants",
+            "enabled": true,
+            "documentSecurity": true,
+            "attributes": [
+                {
+                    "key": "userId",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 255
+                },
+                {
+                    "key": "name",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 255
+                },
+                {
+                    "key": "avatarFileId",
+                    "type": "string",
+                    "required": false,
+                    "array": false,
+                    "size": 255
+                }
+            ],
+            "indexes": [
+                {
+                    "key": "user_index",
+                    "type": "key",
+                    "attributes": ["userId"],
+                    "orders": ["ASC"]
+                }
+            ]
+        },
+        {
+            "$id": "imessageConversations",
+            "$permissions": [
+                "create(\"users\")",
+                "read(\"users\")",
+                "update(\"users\")",
+                "delete(\"users\")"
+            ],
+            "databaseId": "main",
+            "name": "imessageConversations",
+            "enabled": true,
+            "documentSecurity": true,
+            "attributes": [
+                {
+                    "key": "postId",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 255
+                },
+                {
+                    "key": "participantDocRefs",
+                    "type": "string",
+                    "required": true,
+                    "array": true,
+                    "size": 255
+                },
+                {
+                    "key": "rightSideParticipantDocRef",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 255
+                },
+                {
+                    "key": "screenshotMessageIds",
+                    "type": "string",
+                    "required": true,
+                    "array": true,
+                    "size": 100000
+                },
+                {
+                    "key": "totalScreenshots",
+                    "type": "integer",
+                    "required": true,
+                    "array": false
+                }
+            ],
+            "indexes": [
+                {
+                    "key": "post_id_unique_index",
+                    "type": "unique",
+                    "attributes": ["postId"],
+                    "orders": ["ASC"]
+                }
+            ]
+        },
+        {
+            "$id": "imessageMessages",
+            "$permissions": [
+                "create(\"users\")",
+                "read(\"users\")",
+                "update(\"users\")",
+                "delete(\"users\")"
+            ],
+            "databaseId": "main",
+            "name": "imessageMessages",
+            "enabled": true,
+            "documentSecurity": true,
+            "attributes": [
+                {
+                    "key": "conversationId",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 255
+                },
+                {
+                    "key": "messageId",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 255
+                },
+                {
+                    "key": "participantDocId",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 255
+                },
+                {
+                    "key": "content",
+                    "type": "string",
+                    "required": true,
+                    "array": false,
+                    "size": 10000
+                },
+                {
+                    "key": "timestamp",
+                    "type": "datetime",
+                    "required": true,
+                    "array": false
+                },
+                {
+                    "key": "timestampDisplay",
+                    "type": "string",
+                    "required": false,
+                    "array": false,
+                    "size": 50
+                },
+                {
+                    "key": "isEdited",
+                    "type": "boolean",
+                    "required": true,
+                    "array": false
+                },
+                {
+                    "key": "screenshotIndex",
+                    "type": "integer",
+                    "required": true,
+                    "array": false
+                },
+                {
+                    "key": "deliveryStatus",
+                    "type": "string",
+                    "required": false,
+                    "array": false,
+                    "size": 20,
+                    "elements": ["sent", "delivered", "read"],
+                    "format": "enum"
+                }
+            ],
+            "indexes": [
+                {
+                    "key": "conversation_screenshot_index",
+                    "type": "key",
+                    "attributes": ["conversationId", "screenshotIndex"],
+                    "orders": ["ASC", "ASC"]
+                },
+                {
+                    "key": "conversation_timestamp_index",
+                    "type": "key",
+                    "attributes": ["conversationId", "timestamp"],
+                    "orders": ["ASC", "ASC"]
+                },
+                {
+                    "key": "conversation_message_unique_index",
+                    "type": "unique",
+                    "attributes": ["conversationId", "messageId"],
+                    "orders": ["ASC", "ASC"]
+                }
+            ]
         }
     ]
 }

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,8 @@
+!.appwrite/
+!.cursor/
+
+.svelte-kit/
+build/
+cursor/
+*.log
+*.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 test-results
 node_modules
 .cursor/
+cursor/
 .vscode/
 
 # Output

--- a/docs/database/imessage-model.md
+++ b/docs/database/imessage-model.md
@@ -1,0 +1,42 @@
+# iMessage Data Models
+
+This document provides a human-readable overview of the Appwrite collections used for storing iMessage conversation posts: `imessageParticipants`, `imessageConversations`, and `imessageMessages`.
+
+These models are designed to capture the structure and content of iMessage screenshots shared as posts, linking back to the main `posts` collection.
+
+## Collections Overview
+
+### `imessageParticipants`
+
+- **Purpose:** To store details about the individuals participating in an iMessage conversation _as depicted in a screenshot_. These are user-defined participant entries for a specific post and do not necessarily correspond to other users in the application.
+- **Key Fields:** `userId` (creator of the participant entry), `name` (display name), `avatarFileId` (optional avatar).
+- **Usage:** Referenced by conversation and message documents to identify senders and participants.
+
+### `imessageConversations`
+
+- **Purpose:** To represent a single iMessage conversation post, linking it to the main `posts` collection and outlining which participants and messages are included in _this specific screenshot_.
+- **Key Fields:** `postId` (link to `posts` collection), `participantDocRefs` (list of participants in the screenshot), `rightSideParticipantDocRef` (the post creator's participant entry), `screenshotMessageIds` (ordered list of message IDs shown), `totalScreenshots` (if conversation is split).
+- **Usage:** The central document for an iMessage post, providing context and links to related data. The `screenshotMessageIds` field is critical for displaying messages in the correct order for a given post.
+
+### `imessageMessages`
+
+- **Purpose:** To store the content and metadata of individual messages _within a specific iMessage screenshot conversation_.
+- **Key Fields:** `conversationId` (link to `imessageConversations`), `messageId` (unique ID within conversation), `participantDocId` (sender), `content` (message text), `timestamp`, `screenshotIndex` (order in screenshot), `isEdited`, `deliveryStatus` (optional).
+- **Usage:** Contains the actual message content. The `screenshotIndex` field is used in conjunction with `imessageConversations.screenshotMessageIds` to order messages for display.
+
+## Relationships
+
+- An `imessageConversations` document is linked to one `posts` document (`postId`).
+- An `imessageConversations` document references multiple `imessageParticipants` (via `participantDocRefs` and `rightSideParticipantDocRef`).
+- Each `imessageMessages` document belongs to one `imessageConversations` document (`conversationId`).
+- Each `imessageMessages` document references one `imessageParticipants` document (`participantDocId`).
+
+## How Data is Accessed
+
+When viewing an iMessage post, the application typically:
+
+1. Fetches the `imessageConversations` document using the `postId` (which is the `contentRefId` from the `posts` document).
+2. Uses the `participantDocRefs` and `rightSideParticipantDocRef` from the conversation document to fetch the relevant `imessageParticipants` details (names, avatars).
+3. Uses the `conversationId` and the ordered `screenshotMessageIds` from the conversation document to fetch the specific `imessageMessages` that appear in the screenshot, often ordering them by `screenshotIndex`.
+
+This structure allows for efficient retrieval of all necessary data related to a single iMessage screenshot post.

--- a/features/imessage-models-ai-context.md
+++ b/features/imessage-models-ai-context.md
@@ -1,0 +1,72 @@
+# iMessage Models AI Context
+
+This document provides AI-specific context for the Appwrite collections related to iMessage posts (`imessageParticipants`, `imessageConversations`, `imessageMessages`). It details their structure, relationships, and intended usage patterns to assist AI in generating relevant code and understanding data interactions.
+
+## Collections
+
+### `imessageParticipants` (ID: `imessageParticipants`)
+
+- **Description:** Stores participants involved in an iMessage conversation screenshot. These are user-defined names/avatars for the conversation context, not necessarily linked to actual user profiles.
+- **Permissions:** `create("users")`, `read("users")`, `update("users")`, `delete("users")`
+- **Attributes:**
+    - `userId`: `string`, required, size 255. The ID of the user who created this participant record.
+    - `name`: `string`, required, size 255. The display name for the participant.
+    - `avatarFileId`: `string`, optional, size 255. File ID for the participant's avatar image.
+- **Indexes:**
+    - `user_index`: `key` on `userId` (ASC). Allows querying participants by the creating user.
+- **Relationships:** Referenced by `imessageMessages` (`participantDocId`) and `imessageConversations` (`participantDocRefs`, `rightSideParticipantDocRef`).
+- **Query Considerations:** Primarily queried by `userId` to retrieve participants created by a specific user.
+
+### `imessageConversations` (ID: `imessageConversations`)
+
+- **Description:** Represents a single iMessage conversation screenshot post. Links the post to its participants and messages.
+- **Permissions:** `create("users")`, `read("users")`, `update("users")", `delete("users")`
+- **Attributes:**
+    - `postId`: `string`, required, size 255. The ID of the associated `posts` collection document (`contentRefId`).
+    - `participantDocRefs`: `string` array, required, size 255 per element. References to the `imessageParticipants` documents involved in this conversation.
+    - `rightSideParticipantDocRef`: `string`, required, size 255. Reference to the `imessageParticipants` document representing the person on the right side of the conversation (the post creator).
+    - `screenshotMessageIds`: `string` array, required, size 100000 per element. An ordered list of message IDs (`imessageMessages.messageId`) indicating the sequence of messages shown in the screenshot.
+    - `totalScreenshots`: `integer`, required. The total number of screenshot segments for this conversation (relevant if a long conversation is split across multiple posts).
+- **Indexes:**
+    - `post_id_unique_index`: `unique` on `postId` (ASC). Ensures a one-to-one relationship with a `posts` document and allows efficient lookup by post ID.
+- **Relationships:** Links to `posts` (`postId`), references `imessageParticipants` (`participantDocRefs`, `rightSideParticipantDocRef`), and is referenced by `imessageMessages` (`conversationId`).
+- **Query Considerations:** Primarily queried by `postId` to retrieve the conversation details for a specific post. The `screenshotMessageIds` array defines the order and subset of messages relevant to this specific screenshot.
+
+### `imessageMessages` (ID: `imessageMessages`)
+
+- **Description:** Stores individual messages within an iMessage conversation screenshot.
+- **Permissions:** `create("users")`, `read("users")`, `update("users")", `delete("users")`
+- **Attributes:**
+    - `conversationId`: `string`, required, size 255. The ID of the parent `imessageConversations` document.
+    - `messageId`: `string`, required, size 255. A unique identifier for the message within its conversation.
+    - `participantDocId`: `string`, required, size 255. Reference to the `imessageParticipants` document representing the sender of this message.
+    - `content`: `string`, required, size 10000. The text content of the message.
+    - `timestamp`: `datetime`, required. The actual timestamp of the message.
+    - `timestampDisplay`: `string`, optional, size 50. A formatted string representation of the timestamp for display.
+    - `isEdited`: `boolean`, required. Indicates if the message was edited.
+    - `screenshotIndex`: `integer`, required. The index of this message within the sequence shown in the specific conversation screenshot (corresponds to its position in `imessageConversations.screenshotMessageIds`).
+    - `deliveryStatus`: `string`, optional, size 20, enum (`sent`, `delivered`, `read`). The delivery status of the message.
+- **Indexes:**
+    - `conversation_screenshot_index`: `key` on `conversationId` (ASC), `screenshotIndex` (ASC). Allows querying messages for a specific conversation ordered by their appearance in the screenshot.
+    - `conversation_timestamp_index`: `key` on `conversationId` (ASC), `timestamp` (ASC). Allows querying messages for a specific conversation ordered by their original timestamp.
+    - `conversation_message_unique_index`: `unique` on `conversationId` (ASC), `messageId` (ASC). Ensures uniqueness of a message within a conversation and allows efficient lookup by conversation and message ID.
+- **Relationships:** Links to `imessageConversations` (`conversationId`) and `imessageParticipants` (`participantDocId`).
+- **Query Considerations:** Frequently queried by `conversationId`, often with `screenshotIndex` or `timestamp` for ordering. The `conversation_screenshot_index` is crucial for displaying messages in the correct order for a given screenshot post.
+
+## Relationships Summary
+
+- `imessageConversations` links to a `posts` document.
+- `imessageConversations` references `imessageParticipants` (multiple via `participantDocRefs` and one primary via `rightSideParticipantDocRef`).
+- `imessageMessages` links to an `imessageConversations` document.
+- `imessageMessages` references an `imessageParticipants` document (the sender).
+
+## Key Query Patterns
+
+- Retrieving conversation details for a specific iMessage post (`imessageConversations` by `postId`).
+- Retrieving participants associated with a conversation (`imessageParticipants` by looking up IDs from `imessageConversations.participantDocRefs`).
+- Retrieving messages for a specific conversation, ordered by appearance in the screenshot (`imessageMessages` by `conversationId` and `screenshotIndex`).
+- Retrieving messages for a specific conversation, ordered by timestamp (`imessageMessages` by `conversationId` and `timestamp`).
+- Looking up a specific message within a conversation (`imessageMessages` by `conversationId` and `messageId`).
+- Retrieving participants created by a specific user (`imessageParticipants` by `userId`).
+
+This context should help AI understand the data model and how to interact with these collections effectively.


### PR DESCRIPTION
Add Appwrite collections for iMessage posts: imessageParticipants, imessageConversations, and imessageMessages.

These models are designed to store the participants, conversation structure, and individual messages for iMessage screenshot posts.

Changes include:
- Adding collection definitions to `.appwrite/appwrite.json`
- Creating AI context documentation at `features/imessage-models-ai-context.md`
- Creating human-readable documentation at `docs/database/imessage-model.md`

The models are structured to link to the `posts` collection via `contentRefId` (stored as `postId` in `imessageConversations`) and use relationships between the new collections to organize conversation data.